### PR TITLE
BUGFIX: Typo in MailDev YAML Configuration example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -41,7 +41,7 @@ modules:
         base_uri: http://maildev.project
         username: 'user'
         password: 'secret'
-        atheticationType: 'basic'
+        authenticationType: 'basic'
 ```
 
 #### Gherkin steps


### PR DESCRIPTION
Regarding:

https://github.com/punktDe/codeception-maildev/blob/d807943bfc6fb0a42f40d2921bc90fc47c0ceec8/Classes/Module/MailDev.php#L36

It should be: `authenticationType`