### PR TITLE
BUGFIX: check if recipients is a string

### DIFF
--- a/Classes/Domain/Model/Mail.php
+++ b/Classes/Domain/Model/Mail.php
@@ -43,8 +43,8 @@ class Mail
         $this->mailData = $mailData;
 
         $this->body = Arrays::getValueByPath($this->mailData, 'html');
-        $this->recipients = Arrays::getValueByPath($this->mailData, 'headers.To');
-        $this->subject = Arrays::getValueByPath($this->mailData, 'headers.Subject');
+        $this->recipients = Arrays::getValueByPath($this->mailData, 'headers.to');
+        $this->subject = Arrays::getValueByPath($this->mailData, 'headers.subject');
 
     }
 

--- a/Classes/Module/MailDev.php
+++ b/Classes/Module/MailDev.php
@@ -100,10 +100,18 @@ class MailDev extends Module
     public function checkRecipientAddress(string $address): void
     {
         $recipients = $this->currentMail->getRecipients();
-        foreach ($recipients as $recipient) {
-            if ($recipient === $address) {
+        if (is_string($recipients)) {
+            if ($recipients === $address) {
                 return;
             }
+        } elseif (is_array($recipients)) {
+            foreach ($recipients as $recipient) {
+                if ($recipient === $address) {
+                    return;
+                }
+            }
+        } else {
+            throw new \Exception(sprintf('Could not parse mail recipient: %s', print_r($address, true)));
         }
         throw new \Exception(sprintf('Did not find the recipient "%s" in the mail', $address));
     }


### PR DESCRIPTION
# Description

Currently when using: `Then The email is addressed to "mail@example.com"` in Gherkin, you get an exception because `mailIsAddressedTo()` returns expect parameter $address of type array or object, null given. But `$address` is always a string. Since its not possible to assign more than one mail address to the `mailIsAddressedTo()` function.